### PR TITLE
Add 4.14+trunk+nnp and 4.14+trunk+nnp+flambda

### DIFF
--- a/config/custom_navajo.json
+++ b/config/custom_navajo.json
@@ -5,6 +5,18 @@
     "expiry": "2100-01-01"
   },
   {
+    "url": "https://github.com/ocaml/ocaml/archive/4.14.tar.gz",
+    "name": "4.14+trunk+nnp",
+    "expiry": "2100-01-01",
+    "configure": "--disable-naked-pointers"
+  },
+  {
+    "url": "https://github.com/ocaml/ocaml/archive/4.14.tar.gz",
+    "name": "4.14+trunk+nnp+flambda",
+    "expiry": "2100-01-01",
+    "configure": "--disable-naked-pointers --enable-flambda"
+  },
+  {
     "url": "https://github.com/kayceesrk/ocaml/archive/refs/heads/decouple_major_and_minor2.tar.gz",
     "name": "5.1.0+trunk+decouple_major_and_minor2",
     "expiry": "2022-07-10"

--- a/config/custom_turing.json
+++ b/config/custom_turing.json
@@ -5,6 +5,18 @@
     "expiry": "2100-01-01"
   },
   {
+    "url": "https://github.com/ocaml/ocaml/archive/4.14.tar.gz",
+    "name": "4.14+trunk+nnp",
+    "expiry": "2100-01-01",
+    "configure": "--disable-naked-pointers"
+  },
+  {
+    "url": "https://github.com/ocaml/ocaml/archive/4.14.tar.gz",
+    "name": "4.14+trunk+nnp+flambda",
+    "expiry": "2100-01-01",
+    "configure": "--disable-naked-pointers --enable-flambda"
+  },
+  {
     "url": "https://github.com/kayceesrk/ocaml/archive/refs/heads/decouple_major_and_minor2.tar.gz",
     "name": "5.1.0+trunk+decouple_major_and_minor2",
     "expiry": "2022-07-10"


### PR DESCRIPTION
I think it would be a good idea to add the latest OCaml 4 as a comparison point and also to help with 4.14 development. I expect that it fails of course the parallel test, but I hope that it will give helpful figures for the sequential test.
* I have included both flambda and non-flambda configurations. I was hoping to test both `-O2` and `-O3` for flambda, but unfortunately I have not found the config option to pass either option during compilation.
* If tracking 4.14+trunk is going to be too expensive, then we could track instead a fixed commit (e.g. 4.14.0).