### PR TITLE
Introduce workaround to the JCC erratum microcode update

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,3 +49,20 @@ variant build:
 ## UI
 
 The nightly results can be viewed at https://sandmark.ocamllabs.io.
+
+## Platform-specific instructions
+
+The `turing` configuration runs on an Intel Xeon scalable processor
+based on Skylake. It is recommended to apply the workaround to the JCC
+erratum microcode update
+(https://www.intel.com/content/dam/support/us/en/documents/processors/mitigations-jump-conditional-code-erratum.pdf).
+
+To do so, add a line
+```
+    "configure": "CC='gcc -Wa,-mbranches-within-32B' AS='as -mbranches-within-32B'",
+```
+(for gcc) or
+```
+    "configure": "CC='clang -mbranches-within-32B-boundaries' AS='as -mbranches-within-32B'",
+```
+(for clang) to the configuration.

--- a/config/custom_turing.json
+++ b/config/custom_turing.json
@@ -2,26 +2,31 @@
   {
     "url": "https://github.com/ocaml/ocaml/archive/trunk.tar.gz",
     "name": "5.1.0+trunk",
+    "configure": "CC='gcc -Wa,-mbranches-within-32B' AS='as -mbranches-within-32B'",
     "expiry": "2100-01-01"
   },
   {
     "url": "https://github.com/kayceesrk/ocaml/archive/refs/heads/decouple_major_and_minor2.tar.gz",
     "name": "5.1.0+trunk+decouple_major_and_minor2",
+    "configure": "CC='gcc -Wa,-mbranches-within-32B' AS='as -mbranches-within-32B'",
     "expiry": "2022-07-10"
   },
   {
     "url": "https://github.com/stedolan/ocaml/archive/refs/heads/spill-permanently.zip",
     "name": "5.1.0+trunk+stedolan+pr11102",
+    "configure": "CC='gcc -Wa,-mbranches-within-32B' AS='as -mbranches-within-32B'",
     "expiry": "2022-07-26"
   },
   {
     "url": "https://www.github.com/ocaml/ocaml/archive/refs/pull/11307/head.zip",
     "name": "5.1.0+trunk+gadmm+pr11307",
+    "configure": "CC='gcc -Wa,-mbranches-within-32B' AS='as -mbranches-within-32B'",
     "expiry": "2022-09-25"
   },
   {
     "url": "https://www.github.com/ocaml/ocaml/archive/refs/pull/11506/head.zip",
     "name": "5.1.0+trunk+gadmm+pr11506",
+    "configure": "CC='gcc -Wa,-mbranches-within-32B' AS='as -mbranches-within-32B'",
     "expiry": "2022-09-25"
   }
 ]


### PR DESCRIPTION
This is a follow-up to https://github.com/ocaml-bench/sandmark-nightly/issues/85. I would like to see the results with the workaround applied. We do not know yet the impact on the results, this can be removed later (if we notice detrimental effects), or you can decide to keep it.