### PR TITLE
Add 5.1.0+trunk+stedolan+PR11103

### DIFF
--- a/config/custom_navajo.json
+++ b/config/custom_navajo.json
@@ -15,6 +15,11 @@
     "expiry": "2022-07-26"
   },
   {
+    "url": "https://github.com/stedolan/ocaml/archive/refs/heads/linscan-entry.zip",
+    "name": "5.1.0+trunk+stedolan+pr11103",
+    "expiry": "2022-11-02"
+  },
+  {
     "url": "https://www.github.com/ocaml/ocaml/archive/refs/pull/11307/head.zip",
     "name": "5.1.0+trunk+gadmm+pr11307",
     "expiry": "2022-09-25"

--- a/config/custom_turing.json
+++ b/config/custom_turing.json
@@ -18,6 +18,12 @@
     "expiry": "2022-07-26"
   },
   {
+    "url": "https://github.com/stedolan/ocaml/archive/refs/heads/linscan-entry.zip",
+    "name": "5.1.0+trunk+stedolan+pr11103",
+    "configure": "CC='gcc -Wa,-mbranches-within-32B' AS='as -mbranches-within-32B'",
+    "expiry": "2022-11-02"
+  },
+  {
     "url": "https://www.github.com/ocaml/ocaml/archive/refs/pull/11307/head.zip",
     "name": "5.1.0+trunk+gadmm+pr11307",
     "configure": "CC='gcc -Wa,-mbranches-within-32B' AS='as -mbranches-within-32B'",


### PR DESCRIPTION
This PR adds a benchmark run for the `ocaml/ocaml` PR 11103 and should partially address https://github.com/ocurrent/current-bench/issues/374

Xavier Leroy mentions [here](https://github.com/ocaml/ocaml/pull/11103#issuecomment-1064195425) his lack of confidence in using the linear scan allocator since he's not sure how much use it has seen in production. Would it help if we also benchmark the compilation of some packages in the "wild" using this branch, like we do [here](https://autumn.ocamllabs.io/punchagan/ocaml?worker=autumn&image=bench.Dockerfile)?