### PR TITLE
Add new prefetching branches

### DIFF
--- a/config/custom_navajo.json
+++ b/config/custom_navajo.json
@@ -10,8 +10,13 @@
     "expiry": "2022-12-01"
   },
   {
-    "url": "https://github.com/fabbing/ocaml/archive/refs/heads/prefetching.zip",
-    "name": "5.1.0+trunk+fabbing+base_prefetching",
-    "expiry": "2022-12-31"
+    "url": "https://github.com/fabbing/ocaml/archive/97aa649e3c26e5f9ba2e3e5fc88115bc60afa5f9.zip",
+    "name": "5.1.0+trunk+comparison_point_for_prefetching",
+    "expiry": "2023-01-31"
+  },
+  {
+    "url": "https://github.com/fabbing/ocaml/archive/refs/heads/prefetching_like_414.zip",
+    "name": "5.1.0+trunk+fabbing+prefetching_like_414",
+    "expiry": "2023-01-31"
   }
 ]


### PR DESCRIPTION
This add 2 branches for comparing prefetching: `5.1.0+trunk+fabbing+prefetching_like_414` and the parent commit acting as a comparison point (`97aa649e3c26e5f9ba2e3e5fc88115bc60afa5f9`).