### PR TITLE
Add back linscan-entry PR benchmarking

### DIFF
--- a/config/custom_navajo.json
+++ b/config/custom_navajo.json
@@ -5,6 +5,11 @@
     "expiry": "2100-01-01"
   },
   {
+    "url": "https://github.com/stedolan/ocaml/archive/refs/heads/linscan-entry.zip",
+    "name": "5.0.0+trunk+stedolan+pr11103",
+    "expiry": "2023-01-15"
+  },
+  {
     "url": "https://github.com/kayceesrk/ocaml/archive/refs/heads/decouple_major_and_minor3.tar.gz",
     "name": "5.1.0+trunk+decouple_gcs",
     "expiry": "2022-12-01"

--- a/config/custom_turing.json
+++ b/config/custom_turing.json
@@ -6,6 +6,12 @@
     "expiry": "2100-01-01"
   },
   {
+    "url": "https://github.com/stedolan/ocaml/archive/refs/heads/linscan-entry.zip",
+    "name": "5.0.0+trunk+stedolan+pr11103",
+    "configure": "CC='gcc -Wa,-mbranches-within-32B' AS='as -mbranches-within-32B'",
+    "expiry": "2023-01-15"
+  },
+  {
     "url": "https://github.com/kayceesrk/ocaml/archive/refs/heads/decouple_major_and_minor3.tar.gz",
     "name": "5.1.0+trunk+decouple_gcs",
     "configure": "CC='gcc -Wa,-mbranches-within-32B' AS='as -mbranches-within-32B'",


### PR DESCRIPTION
The PR wasn't run in the past, since Sandmark didn't support custom versions of OCaml for PRs and only supported 5.1.0. We now support custom runs running with different versions of OCaml

Related #12 and e1bf8847bc0cfbd9276f9464bbe407a5133d8394