### PR TITLE
Add aligned alloc PR

### DIFF
--- a/config/custom_navajo.json
+++ b/config/custom_navajo.json
@@ -14,5 +14,10 @@
     "name": "5.2.0+trunk+tsan",
     "expiry": "2023-05-31",
     "configure": "--enable-tsan"
+  },
+  {
+    "url": "https://github.com/bartoszmodelski/ocaml/archive/refs/heads/aligned-alloc.tar.gz",
+    "name": "5.2.0+trunk+bartoszmodelski+pr12212",
+    "expiry": "2023-05-30"
   }
 ]

--- a/config/custom_turing.json
+++ b/config/custom_turing.json
@@ -10,5 +10,11 @@
     "name": "5.2.0+trunk+fix-idle-gc",
     "configure": "CC='gcc -Wa,-mbranches-within-32B' AS='as -mbranches-within-32B'",
     "expiry": "2023-05-01"
+  },
+  {
+    "url": "https://github.com/bartoszmodelski/ocaml/archive/refs/heads/aligned-alloc.tar.gz",
+    "name": "5.2.0+trunk+bartoszmodelski+pr12212",
+    "configure": "CC='gcc -Wa,-mbranches-within-32B' AS='as -mbranches-within-32B'",
+    "expiry": "2023-05-30"
   }
 ]


### PR DESCRIPTION
Add aligned alloc [PR](https://github.com/ocaml/ocaml/pull/12212) to sandmark. Just to ensure changes in sizeclasses bring no surprises. 

Adding to both machines per @shakthimaan.

Testing: 
```
$ make all                                                                      
Info: config/custom_navajo.json parsed correctly
Info: config/custom_turing.json parsed correctly
Info: URL https://github.com/ocaml/ocaml/archive/trunk.tar.gz exists
Info: URL https://github.com/damiendoligez/ocaml/archive/refs/heads/fix-idle-domain-gc.tar.gz exists
Info: URL https://github.com/ocaml-multicore/ocaml-tsan/archive/refs/heads/tsan_patch.zip exists
Info: URL https://github.com/bartoszmodelski/ocaml/archive/refs/heads/aligned-alloc.tar.gz exists
Info: URL https://github.com/ocaml/ocaml/archive/trunk.tar.gz exists
Info: URL https://github.com/damiendoligez/ocaml/archive/refs/heads/fix-idle-domain-gc.tar.gz exists
Info: URL https://github.com/bartoszmodelski/ocaml/archive/refs/heads/aligned-alloc.tar.gz exists
```