### PR TITLE
Add 5.0.0 and 5.1.0 release runs, expiring tomorrow

### DIFF
--- a/config/custom_navajo.json
+++ b/config/custom_navajo.json
@@ -24,5 +24,15 @@
     "url": "https://github.com/eutro/ocaml/archive/refs/heads/tsdnr-barriers.tar.gz",
     "name": "5.2.0+trunk+eutro+barriers",
     "expiry": "2023-09-30"
+  },
+  {
+    "url": "https://github.com/ocaml/ocaml/archive/refs/tags/5.0.0.tar.gz",
+    "name": "5.0.0+release",
+    "expiry": "2023-09-15"
+  },
+  {
+    "url": "https://github.com/ocaml/ocaml/archive/refs/tags/5.1.0.tar.gz",
+    "name": "5.1.0+release",
+    "expiry": "2023-09-15"
   }
 ]

--- a/config/custom_navajo.json
+++ b/config/custom_navajo.json
@@ -26,12 +26,12 @@
     "expiry": "2023-09-30"
   },
   {
-    "url": "https://github.com/ocaml/ocaml/archive/refs/tags/5.0.0.tar.gz",
+    "url": "https://github.com/ocaml/ocaml/archive/5.0.0.tar.gz",
     "name": "5.0.0+release",
     "expiry": "2023-09-15"
   },
   {
-    "url": "https://github.com/ocaml/ocaml/archive/refs/tags/5.1.0.tar.gz",
+    "url": "https://github.com/ocaml/ocaml/archive/5.1.0.tar.gz",
     "name": "5.1.0+release",
     "expiry": "2023-09-15"
   }

--- a/config/custom_turing.json
+++ b/config/custom_turing.json
@@ -24,13 +24,13 @@
     "expiry": "2023-09-30"
   },
   {
-    "url": "https://github.com/ocaml/ocaml/archive/refs/tags/5.0.0.tar.gz",
+    "url": "https://github.com/ocaml/ocaml/archive/5.0.0.tar.gz",
     "name": "5.0.0+release",
     "configure": "CC='gcc -Wa,-mbranches-within-32B' AS='as -mbranches-within-32B'",
     "expiry": "2023-09-15"
   },
   {
-    "url": "https://github.com/ocaml/ocaml/archive/refs/tags/5.1.0.tar.gz",
+    "url": "https://github.com/ocaml/ocaml/archive/5.1.0.tar.gz",
     "name": "5.1.0+release",
     "configure": "CC='gcc -Wa,-mbranches-within-32B' AS='as -mbranches-within-32B'",
     "expiry": "2023-09-15"

--- a/config/custom_turing.json
+++ b/config/custom_turing.json
@@ -22,5 +22,17 @@
     "name": "5.2.0+trunk+eutro+barriers",
     "configure": "CC='gcc -Wa,-mbranches-within-32B' AS='as -mbranches-within-32B'",
     "expiry": "2023-09-30"
+  },
+  {
+    "url": "https://github.com/ocaml/ocaml/archive/refs/tags/5.0.0.tar.gz",
+    "name": "5.0.0+release",
+    "configure": "CC='gcc -Wa,-mbranches-within-32B' AS='as -mbranches-within-32B'",
+    "expiry": "2023-09-15"
+  },
+  {
+    "url": "https://github.com/ocaml/ocaml/archive/refs/tags/5.1.0.tar.gz",
+    "name": "5.1.0+release",
+    "configure": "CC='gcc -Wa,-mbranches-within-32B' AS='as -mbranches-within-32B'",
+    "expiry": "2023-09-15"
   }
 ]


### PR DESCRIPTION
Here's an attempt at adding benchmark runs of the 5.0.0 and 5.1.0 releases for future reference.
I've set them to expire tomorrow, which will need changing if they don't get to run tonight.