### PR TITLE
Add 5.0.0 and 5.1.0 runs, take 2

### DIFF
--- a/config/custom_navajo.json
+++ b/config/custom_navajo.json
@@ -27,12 +27,12 @@
   },
   {
     "url": "https://github.com/ocaml/ocaml/archive/5.0.0.tar.gz",
-    "name": "5.0.0+release",
-    "expiry": "2023-09-15"
+    "name": "5.0.0+stable+release",
+    "expiry": "2023-09-16"
   },
   {
     "url": "https://github.com/ocaml/ocaml/archive/5.1.0.tar.gz",
-    "name": "5.1.0+release",
-    "expiry": "2023-09-15"
+    "name": "5.1.0+stable+release",
+    "expiry": "2023-09-16"
   }
 ]

--- a/config/custom_turing.json
+++ b/config/custom_turing.json
@@ -25,14 +25,14 @@
   },
   {
     "url": "https://github.com/ocaml/ocaml/archive/5.0.0.tar.gz",
-    "name": "5.0.0+release",
+    "name": "5.0.0+stable+release",
     "configure": "CC='gcc -Wa,-mbranches-within-32B' AS='as -mbranches-within-32B'",
-    "expiry": "2023-09-15"
+    "expiry": "2023-09-16"
   },
   {
     "url": "https://github.com/ocaml/ocaml/archive/5.1.0.tar.gz",
-    "name": "5.1.0+release",
+    "name": "5.1.0+stable+release",
     "configure": "CC='gcc -Wa,-mbranches-within-32B' AS='as -mbranches-within-32B'",
-    "expiry": "2023-09-15"
+    "expiry": "2023-09-16"
   }
 ]


### PR DESCRIPTION
This is a second attempt with adjusted names and expiry dates.

I've tested locally that this should now hit the desired json-file when piped through the validation regexp in
https://github.com/ocaml-bench/sandmark-nightly-config/blob/7a1dfa5eb8aeebdc7802127ac3fc33e19bffd06f/scripts/check-variant-name.sh#L16
```shell
$ grep -oP "^(\\d|\.)+(\\+(trunk|stable))*" <<< "5.0.0+stable+release"
5.0.0+stable
$ grep -oP "^(\\d|\.)+(\\+(trunk|stable))*" <<< "5.1.0+stable+release"
5.1.0+stable
```