### PR TITLE
Fix exit code in scripts/check-variant-name.sh

### DIFF
--- a/scripts/check-variant-name.sh
+++ b/scripts/check-variant-name.sh
@@ -9,6 +9,7 @@ then
     git clone https://github.com/ocaml-bench/sandmark.git "${SANDMARK_DIR}"
 fi
 
+num_err=0
 
 for f in `find config/*.json`; do
     NAMES=$(jq -r 'if type=="array" then .[].name else .name end' "${f}");
@@ -17,6 +18,11 @@ for f in `find config/*.json`; do
         variant_json="${SANDMARK_DIR}/ocaml-versions/${variant}.json"
         if [[ ! -f "${variant_json}" ]]; then
             echo "${variant} is not a valid variant. See https://github.com/ocaml-bench/sandmark/tree/main/ocaml-versions for supported versions!"
+            num_err=$((num_err+1))
         fi
     done
 done
+
+if [[ $num_err -ne 0 ]]; then
+    exit 1
+fi


### PR DESCRIPTION
This little PR adjusts the verifier to exit with code 1 when the check fails.
Without a failure exit code, GitHub shows a nice green checkmark despite validation failure.

I have checked locally that with the fix, the error in #24 gives rise to an error code:
```
$ ./scripts/check-variant-name.sh 
5.0.0 is not a valid variant. See https://github.com/ocaml-bench/sandmark/tree/main/ocaml-versions for supported versions!
5.1.0 is not a valid variant. See https://github.com/ocaml-bench/sandmark/tree/main/ocaml-versions for supported versions!
$ echo $?
1
```
and that the current json-files do not raise any errors and exits with 0 (success):
```
$ ./scripts/check-variant-name.sh 
$ echo $?
0
```