### PR TITLE
Re-add eutro/tsdnr-barriers branch

### DIFF
--- a/config/custom_navajo.json
+++ b/config/custom_navajo.json
@@ -8,5 +8,10 @@
     "url": "https://github.com/johan511/ocaml/archive/refs/heads/oldify_races.zip",
     "name": "5.3.0+trunk+gc-alloc-race-fix",
     "expiry": "2024-01-17"
+  },
+  {
+    "url": "https://github.com/eutro/ocaml/archive/refs/heads/tsdnr-barriers.zip",
+    "name": "5.3.0+trunk+eutro+barriers",
+    "expiry": "2024-03-19"
   }
 ]

--- a/config/custom_turing.json
+++ b/config/custom_turing.json
@@ -10,5 +10,11 @@
     "name": "5.3.0+trunk+gc-alloc-race-fix",
     "configure": "CC='gcc -Wa,-mbranches-within-32B' AS='as -mbranches-within-32B'",
     "expiry": "2024-01-17"
+  },
+  {
+    "url": "https://github.com/eutro/ocaml/archive/refs/heads/tsdnr-barriers.zip",
+    "name": "5.3.0+trunk+eutro+barriers",
+    "configure": "CC='gcc -Wa,-mbranches-within-32B' AS='as -mbranches-within-32B'",
+    "expiry": "2024-03-19"
   }
 ]


### PR DESCRIPTION
This PR [re](/ocaml-bench/sandmark-nightly-config/pull/23)-adds my https://github.com/ocaml/ocaml/pull/12579/ branch to the configs, for just over 2 months this time.