### PR TITLE
Re-run benchmarks for older versions of OCaml

### DIFF
--- a/config/custom_navajo.json
+++ b/config/custom_navajo.json
@@ -5,9 +5,14 @@
     "expiry": "2100-01-01"
   },
   {
-    "url": "https://github.com/johan511/ocaml/archive/refs/heads/oldify_races.zip",
-    "name": "5.3.0+trunk+gc-alloc-race-fix",
-    "expiry": "2024-01-17"
+    "url": "https://github.com/ocaml/ocaml/archive/refs/heads/5.0.zip",
+    "name": "5.0.1+trunk",
+    "expiry": "2024-02-10"
+  },
+  {
+    "url": "https://github.com/ocaml/ocaml/archive/refs/heads/5.2.zip",
+    "name": "5.2.0+trunk",
+    "expiry": "2024-02-10"
   },
   {
     "url": "https://github.com/eutro/ocaml/archive/refs/heads/tsdnr-barriers.zip",


### PR DESCRIPTION
@tmcgilchrist added an Owl GC regression test case in ocaml-bench/sandmark#464 and the results for 5.0 and 5.2 versions are required for a comparison.