### PR TITLE
Docs: Add link describing the CI machines

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,9 +12,10 @@ benchmarks are built and executed, by default, for each entry.
 
 The `config` folder includes two JSON files, `custom_navajo.json` and
 `custom_turing.json`, for running the benchmarks on the Navajo and
-Turing servers respectively. You are encouraged to create a PR for
-your compiler development branch to be executed nightly on both the
-server machines. The following three URLs are supported:
+Turing servers respectively (see [sandmark.ocamllabs.io for more details about these machines](https://sandmark.ocamllabs.io/#machines-used-for-generating-results)).
+You are encouraged to create a PR for your compiler development branch
+to be executed nightly on both the server machines. The following three
+URLs are supported:
 
 1. `Branch`: A compiler development branch whose changes need to be compared nightly.
 

--- a/config/custom_turing.json
+++ b/config/custom_turing.json
@@ -22,5 +22,21 @@
     "name": "5.3.0+trunk+eutro+barriers",
     "configure": "CC='gcc -Wa,-mbranches-within-32B' AS='as -mbranches-within-32B'",
     "expiry": "2024-03-19"
-  }
+  },
+  {
+    "url": "https://github.com/sadiqj/ocaml/archive/refs/heads/larger_pools.zip",
+    "name": "5.3.0+trunk+larger_pools",
+    "expiry": "2024-03-19"
+  },
+  {
+    "url": "https://github.com/sadiqj/ocaml/archive/refs/heads/batch_pool_alloc.zip",
+    "name": "5.3.0+trunk+batch_pool_alloc",
+    "expiry": "2024-03-19"
+  },
+  {
+    "url": "https://github.com/ocaml/ocaml/archive/trunk.tar.gz",
+    "name": "5.3.0+trunk+vanilla",
+    "configure": "",
+    "expiry": "2100-01-01"
+  }  
 ]


### PR DESCRIPTION
When I started reading, it wasn't obvious what the two machines were. Eventually discovered them on the sandmarks page. Seems helpful to link it for easier comprehension.