### PR TITLE
Benchmark +fp against mainline 5.1.1

### DIFF
--- a/config/custom_navajo.json
+++ b/config/custom_navajo.json
@@ -21,12 +21,13 @@
   },
   {
     "url": "https://github.com/ocaml/ocaml/archive/5.1.1.tar.gz",
-    "name": "5.1.1",
-    "expiry": "2100-01-01"
+    "name": "5.1.1+trunk",
+    "expiry": "2024-03-25"
   },
   {
     "url": "https://github.com/ocaml/ocaml/archive/5.1.1.tar.gz",
-    "name": "5.1.1+fp",
-    "expiry": "2100-01-01"
-  },
+    "name": "5.1.1+trunk+fp",
+    "expiry": "2024-03-25",
+    "configure": "--enable-frame-pointers"
+  }
 ]

--- a/config/custom_navajo.json
+++ b/config/custom_navajo.json
@@ -18,5 +18,15 @@
     "url": "https://github.com/eutro/ocaml/archive/refs/heads/tsdnr-barriers.zip",
     "name": "5.3.0+trunk+eutro+barriers",
     "expiry": "2024-03-19"
-  }
+  },
+  {
+    "url": "https://github.com/ocaml/ocaml/archive/5.1.1.tar.gz",
+    "name": "5.1.1",
+    "expiry": "2100-01-01"
+  },
+  {
+    "url": "https://github.com/ocaml/ocaml/archive/5.1.1.tar.gz",
+    "name": "5.1.1+fp",
+    "expiry": "2100-01-01"
+  },
 ]

--- a/config/custom_turing.json
+++ b/config/custom_turing.json
@@ -38,5 +38,16 @@
     "name": "5.3.0+trunk+vanilla",
     "configure": "",
     "expiry": "2100-01-01"
-  }  
+  },
+  {
+    "url": "https://github.com/ocaml/ocaml/archive/5.1.1.tar.gz",
+    "name": "5.1.1+trunk",
+    "expiry": "2024-03-25"
+  },
+  {
+    "url": "https://github.com/ocaml/ocaml/archive/5.1.1.tar.gz",
+    "name": "5.1.1+trunk+fp",
+    "expiry": "2024-03-25",
+    "configure": "--enable-frame-pointers"
+  }
 ]


### PR DESCRIPTION
The new [post about frame pointers by Brendan Gregg ](https://www.brendangregg.com/blog/2024-03-17/the-return-of-the-frame-pointers.html) has made me curious about how the `+fp` variant of the compiler performs against mainline.

Notes for reviewer:
1. Should it be `5.1.1` or `5.1.1+stable`?
2. I'm unsure, at this point, what the expiry should be. Feedback is very welcome.